### PR TITLE
Wrap RootLayout in CartProvider to fix 500 error on product detail page

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import type { ReactNode } from 'react';
+import { CartProvider } from '../components/cart-context';
 
 export const metadata = {
   title: 'Verdulería Sostenible',
@@ -10,7 +11,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="es-CL">
       <head />
-      <body>{children}</body>
+      <body>
+        <CartProvider>{children}</CartProvider>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
### What

This MR wraps the application root layout in `CartProvider` so that `useCart` can be used within client components such as `AddToCartButton` on the product detail page. Without this, the page errors with:
```
useCart must be used within CartProvider
```

### Ticket
Fixes 500 error when accessing `/producto/[slug]`